### PR TITLE
Missing namespace in data source is detected when setting

### DIFF
--- a/lib/settings/settings.rb
+++ b/lib/settings/settings.rb
@@ -98,9 +98,21 @@ class Settings
 
   def set_object(receiver, namespace, strict)
     logger.opt_trace "Setting #{receiver} object (#{digest(namespace, nil, strict)})"
+
     data = get(namespace)
-    data.each {|attribute, value| Settings::Setting::Assignment::Object.assign(receiver, attribute.to_sym, value, strict) }
+
+    if data.nil?
+      msg = "#{namespace} not found in the data"
+      logger.error msg
+      raise Settings::Error, msg
+    end
+
+    data.each do |attribute, value|
+      Settings::Setting::Assignment::Object.assign(receiver, attribute.to_sym, value, strict)
+    end
+
     logger.opt_debug "Set #{receiver} object (#{digest(namespace, nil, strict)})"
+
     receiver
   end
 

--- a/test/bench/set_object_from_namespace.rb
+++ b/test/bench/set_object_from_namespace.rb
@@ -29,4 +29,12 @@ context "Set an object from a namespace" do
 
     assert(example.some_setting == "some value")
   end
+
+  test "When namespace isn't found in data, it's an error" do
+    example = SetObjectFromNamespace.example
+
+    assert proc { SetObjectFromNamespace.settings.set example, "other_namespace" } do
+      raises_error? Settings::Error
+    end
+  end
 end


### PR DESCRIPTION
When applying settings from a namespace within a data source, the
previous behavior when said namespace wasn't found in the data was
confusing. Suppose the following data source and class:

```
example_data_source = {
  some_namespace: {
    host: "localhost",
    port: 2113
  }
}

example_settings = Settings.build example_data_source

class SomeClass
  setting :host
  setting :port
end
```

If you attempted to supply an instance of `SomeClass` with
`example_settings`, and got the namespace wrong, the previous behavior
was a `NoMethodError` for `#each` on `NilClass`.

```
# This would raise NoMethodError #each on NilClass
example_settings.set(SomeClass.new, :wrong_namespace)
```

This commit causes the same code to raise a `Settings::Error` with a
message indicating that the namespace `:wrong_namespace` was not found
in the data source.
