### PR TITLE
Deprecated actuator removed

### DIFF
--- a/lib/settings/data_source/build.rb
+++ b/lib/settings/data_source/build.rb
@@ -5,7 +5,6 @@ class Settings
         data_source_type = type(input)
         data_source_type.build(input)
       end
-      class << self; alias :! :call; end # TODO: Remove deprecated actuator [Kelsey, Thu Oct 08 2015]
 
       def self.type(input=nil)
         return Settings::DataSource::Hash if input.is_a?(::Hash)


### PR DESCRIPTION
Resolves [#71](https://github.com/eventide-project/eventide/issues/71) (Remove all legacy uses of ! as an object's actuator)